### PR TITLE
Opt. search for DN before bind (e.g. if DN does not contain username)

### DIFF
--- a/LdapClient.php
+++ b/LdapClient.php
@@ -30,6 +30,7 @@ class LdapClient implements LdapClientInterface
     private $useStartTls;
     private $optReferrals;
     private $connection;
+    private $charmaps;
 
     /**
      * Constructor.
@@ -68,7 +69,17 @@ class LdapClient implements LdapClientInterface
         if (!$this->connection) {
             $this->connect();
         }
-
+		
+		$dnArr = explode(";",$dn);
+		if(count($dnArr) > 1)
+		{
+			$searchResult = $this->find($dnArr[1], $dnArr[0], '*');
+			
+			if(count($searchResult))
+			{
+				$dn = $searchResult[0]['dn'];
+			}
+		}
         if (false === @ldap_bind($this->connection, $dn, $password)) {
             throw new ConnectionException(ldap_error($this->connection));
         }


### PR DESCRIPTION
The LDAP bind operation allows only the primary DN to be used. In some setups, this DN is not known, since e.g. the common name (CN) is part of the DN instead of the UID.
For such cases, the DN is retrieved by a query beforehand. The "query" part of the DN is to be separated by a ";".