### PR TITLE
Fixing 'TypeError' in LdapUser::getSalt()

### DIFF
--- a/Security/LdapUser.php
+++ b/Security/LdapUser.php
@@ -67,6 +67,7 @@ class LdapUser implements UserInterface, EquatableInterface
      */
     public function getSalt(): ?string
     {
+        return null;
     }
 
     /**


### PR DESCRIPTION
Return value of Symfony\Component\Ldap\Security\LdapUser::getSalt() must be of the type string or null, none returned