### PR TITLE
Allow consumers of symfony/ldap to force the attributes returned to b…

### DIFF
--- a/Entry.php
+++ b/Entry.php
@@ -18,11 +18,16 @@ class Entry
 {
     private $dn;
     private $attributes;
+    private $force_lowercase_attributes;
 
-    public function __construct(string $dn, array $attributes = [])
+    public function __construct(string $dn, array $attributes = [], bool $force_lowercase_attributes = false)
     {
         $this->dn = $dn;
         $this->attributes = $attributes;
+
+        if ($force_lowercase_attributes) {
+          $this->attributes = array_change_key_case($attributes);
+        }
     }
 
     /**


### PR DESCRIPTION
…e all lowercase, to force case insensitivity and enforce a standard (if desired) for the consumer software.

 Why? Companies have different AD setups, some force certain naming conventions, that developers may not know what and why. Coding around these pseudo standards introduces complex code that isn't necessary.  Allowing the SE to force all lowercase attributes will ease their utilization of symfony/ldap and overall (I think) have better quality code.