### PR TITLE
Use hexadecimal numerals instead of hexadecimals in strings to repres…

### DIFF
--- a/Adapter/ExtLdap/Connection.php
+++ b/Adapter/ExtLdap/Connection.php
@@ -25,9 +25,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Connection extends AbstractConnection
 {
-    private const LDAP_INVALID_CREDENTIALS = '0x31';
-    private const LDAP_TIMEOUT = '0x55';
-    private const LDAP_ALREADY_EXISTS = '0x44';
+    private const LDAP_INVALID_CREDENTIALS = 0x31;
+    private const LDAP_TIMEOUT = 0x55;
+    private const LDAP_ALREADY_EXISTS = 0x44;
 
     /** @var bool */
     private $bound = false;


### PR DESCRIPTION
…ent error codes.

This may close issues:
https://github.com/symfony/symfony/issues/37577
https://github.com/symfony/symfony/issues/36327


Instead of comparing a string with hexadecimal in it to return value of ldap_errno(), the adapted will now use the hexadecimal numeral.