### PR TITLE
Incorrect determination of RelativeDistinguishedName for the "move" operation

### DIFF
--- a/Adapter/ExtLdap/EntryManager.php
+++ b/Adapter/ExtLdap/EntryManager.php
@@ -159,7 +159,7 @@ class EntryManager implements EntryManagerInterface
 
     private function parseRdnFromEntry(Entry $entry): string
     {
-        if (!preg_match('/^([^,]+),/', $entry->getDn(), $matches)) {
+        if (!preg_match('/(^[^,\\\\]*(?:\\\\.[^,\\\\]*)*),/', $entry->getDn(), $matches)) {
             throw new LdapException(sprintf('Entry "%s" malformed, could not parse RDN.', $entry->getDn()));
         }
 


### PR DESCRIPTION
If the specified "DistinguishedName" contains a comma in the first value, the first "RelativeDistinguishedName" was determined incorrectly. 
The regular expression now matches up to the first comma which was not escaped with backslash. 

Testing private methods is a bit messy here. However, I thought it was better than testing this against an LDAP server.  

Source: https://tools.ietf.org/html/rfc4514#section-3