### PR TITLE
Add sasl_bind and whoami support

### DIFF
--- a/Adapter/ConnectionInterface.php
+++ b/Adapter/ConnectionInterface.php
@@ -35,4 +35,24 @@ interface ConnectionInterface
      * @throws InvalidCredentialsException When the connection can't be created because of an LDAP_INVALID_CREDENTIALS error
      */
     public function bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null): void;
+
+    /**
+     * Binds the connection against a user's DN and password using SASL
+     *
+     * @return void
+     *
+     * @throws LdapException               When SASL support is not available
+     * @throws AlreadyExistsException      When the connection can't be created because of an LDAP_ALREADY_EXISTS error
+     * @throws ConnectionTimeoutException  When the connection can't be created because of an LDAP_TIMEOUT error
+     * @throws InvalidCredentialsException When the connection can't be created because of an LDAP_INVALID_CREDENTIALS error
+     */
+    public function sasl_bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null);
+
+    /**
+     * Return authenticated and authorized (for SASL) DN
+     *
+     * @return string|null
+     */
+    public function whoami(): string|null;
+
 }

--- a/Ldap.php
+++ b/Ldap.php
@@ -34,6 +34,16 @@ final class Ldap implements LdapInterface
         $this->adapter->getConnection()->bind($dn, $password);
     }
 
+    public function sasl_bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): void
+    {
+        $this->adapter->getConnection()->sasl_bind($dn, $password, $mech, $realm, $authc_id, $authz_id, $props);
+    }
+
+    public function whoami(): string|null
+    {
+        return $this->adapter->getConnection()->whoami();
+    }
+
     public function query(string $dn, string $query, array $options = []): QueryInterface
     {
         return $this->adapter->createQuery($dn, $query, $options);

--- a/LdapInterface.php
+++ b/LdapInterface.php
@@ -33,6 +33,23 @@ interface LdapInterface
     public function bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null): void;
 
     /**
+     * Return a connection bound to the ldap using SASL
+     *
+     * @return void
+     *
+     * @throws ConnectionException if dn / password could not be bound
+     */
+    public function sasl_bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null);
+
+
+    /**
+     * Return authenticated and authorized (for SASL) DN
+     *
+     * @return string|null
+     */
+    public function whoami(): string|null;
+
+    /**
      * Queries a ldap server for entries matching the given criteria.
      */
     public function query(string $dn, string $query, array $options = []): QueryInterface;


### PR DESCRIPTION
SASL bind let the caller supply various options, including proxy authentication, where one user uses its own credentials to login as another one (subjected to LDAP directory access contro usingl authzFrom/authzTo attributes). In this case, ldapwhoami is used to retreive the resulting authenticated and authorized DN after bind success.

Tested with SimpleSAMLphp 2.2.2 with minor patches.